### PR TITLE
JENKINS-58753: Jenkins proxy settings support.

### DIFF
--- a/src/main/java/io/jenkins/plugins/zoom/ZoomNotifier.java
+++ b/src/main/java/io/jenkins/plugins/zoom/ZoomNotifier.java
@@ -27,6 +27,8 @@ public class ZoomNotifier extends Notifier {
     @DataBoundSetter
     private String authToken;
     @DataBoundSetter
+    private boolean jenkinsProxyUsed;
+    @DataBoundSetter
     private boolean notifyStart;
     @DataBoundSetter
     private boolean notifySuccess;
@@ -67,7 +69,7 @@ public class ZoomNotifier extends Notifier {
         listener.getLogger().println("---------------------- Prebuild ----------------------");
         if(notifyStart){
             MessageBuilder messageBuilder = new MessageBuilder(this, build, listener);
-            ZoomNotifyClient.notify(this.webhookUrl, this.authToken, messageBuilder.prebuild());
+            ZoomNotifyClient.notify(this.webhookUrl, this.authToken, this.jenkinsProxyUsed, messageBuilder.prebuild());
         }
         return super.prebuild(build, listener);
     }
@@ -79,7 +81,7 @@ public class ZoomNotifier extends Notifier {
         listener.getLogger().println("---------------------- Perform ----------------------");
         if(notifyPerform(build)){
             MessageBuilder messageBuilder = new MessageBuilder(this, build, listener);
-            ZoomNotifyClient.notify(this.webhookUrl, this.authToken, messageBuilder.build());
+            ZoomNotifyClient.notify(this.webhookUrl, this.authToken, this.jenkinsProxyUsed, messageBuilder.build());
         }
         return true;
     }
@@ -139,9 +141,10 @@ public class ZoomNotifier extends Notifier {
 
         @POST
         public FormValidation doTestConnection(@QueryParameter("webhookUrl") final String webhookUrl,
-                                               @QueryParameter("authToken") final String authToken){
+                                               @QueryParameter("authToken") final String authToken,
+                                               @QueryParameter("jenkinsProxyUsed") final boolean jenkinsProxyUsed){
             Jenkins.get().checkPermission(Permission.CONFIGURE);
-            if(ZoomNotifyClient.notify(webhookUrl, authToken, null)){
+            if(ZoomNotifyClient.notify(webhookUrl, authToken, jenkinsProxyUsed, null)){
                 return FormValidation.ok("Connection is ok");
             }
             return FormValidation.error("Connect failed");

--- a/src/main/java/io/jenkins/plugins/zoom/ZoomNotifyClient.java
+++ b/src/main/java/io/jenkins/plugins/zoom/ZoomNotifyClient.java
@@ -1,43 +1,46 @@
 package io.jenkins.plugins.zoom;
 
+import hudson.ProxyConfiguration;
 import lombok.extern.slf4j.Slf4j;
+
 import org.apache.http.HttpEntity;
+import org.apache.http.HttpHost;
 import org.apache.http.HttpStatus;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.CredentialsProvider;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.client.HttpClients;
+import org.apache.http.impl.conn.DefaultProxyRoutePlanner;
 import org.apache.http.util.EntityUtils;
 
 import java.io.IOException;
-import java.net.URISyntaxException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.List;
+import java.util.regex.Pattern;
 
 @Slf4j
 public class ZoomNotifyClient{
 
-    private static CloseableHttpClient httpclient = HttpClients.createDefault();
+    private static CloseableHttpClient defaultHttpClient = HttpClients.createDefault();
 
-    public static boolean notify(String url, String authToken, String message) {
+    public static boolean notify(String url, String authToken, boolean jenkinsProxyUsed, String message) {
         boolean success = false;
         log.info("Send notification to {}, message: {}", url, message);
         if(url == null || url.isEmpty()){
             log.error("Invalid URL: {}", url);
             return success;
         }
-        HttpPost httpPost = null;
         try {
-            httpPost = new HttpPost(url);
-            httpPost.setHeader("content-type", "application/json;charset=UTF-8");
-            if(authToken != null && !authToken.isEmpty()){
-                httpPost.setHeader("Authorization", authToken);
-            }
-            if(message != null && !message.isEmpty()){
-                StringEntity stringEntity = new StringEntity(message, "UTF-8");
-                stringEntity.setContentEncoding("UTF-8");
-                httpPost.setEntity(stringEntity);
-            }
-            CloseableHttpResponse response = httpclient.execute(httpPost);
+            CloseableHttpResponse response = jenkinsProxyUsed
+                    ? notifyWithProxy(url, authToken, message)
+                    : notifyNoProxy(url, authToken, message);
             int responseCode = response.getStatusLine().getStatusCode();
             HttpEntity entity = response.getEntity();
             log.info("Response code: {}", responseCode);
@@ -51,12 +54,98 @@ public class ZoomNotifyClient{
             log.error("Invalid URL: {}", url);
         } catch (IOException e2) {
             log.error("Error posting to Zoom, url: {}, message: {}", url, message);
+        } 
+        log.info("Notify success? {}", success);
+        return success;
+    }
+
+    private static CloseableHttpResponse notifyWithProxy(String url, String authToken, String message) throws IOException {
+        CloseableHttpResponse response = null;
+        ProxyConfiguration proxyConfig = null;
+        try {
+            proxyConfig = ProxyConfiguration.load();
+        } catch (IOException e) {
+            log.error("Error while loading the proxy configuration");
+        }
+        if(proxyConfig != null
+                && proxyConfig.name != null && !proxyConfig.name.isEmpty()
+                && proxyConfig.port > 0
+                && !isNoProxyHost(url, proxyConfig.getNoProxyHostPatterns())
+        )
+        {
+            HttpClientBuilder builder = HttpClients.custom();
+            HttpHost proxyHost = new HttpHost(proxyConfig.name, proxyConfig.port);
+            DefaultProxyRoutePlanner routePlanner = new DefaultProxyRoutePlanner(proxyHost);
+            builder.setRoutePlanner(routePlanner);
+            String username = proxyConfig.getUserName();
+            if(username != null && !username.isEmpty()) {
+                CredentialsProvider credsProvider = new BasicCredentialsProvider();
+                credsProvider.setCredentials(
+                        new AuthScope(proxyConfig.name, proxyConfig.port),
+                        new UsernamePasswordCredentials(username, proxyConfig.getPassword()));
+                builder.setDefaultCredentialsProvider(credsProvider);
+            }
+            CloseableHttpClient customHttpClient = builder.build();
+            try {
+                response = doPost(customHttpClient, url, authToken, message);
+            }
+            finally {
+                customHttpClient.close();
+            }
+        }
+        else {
+            response = notifyNoProxy(url, authToken, message);
+        }
+        return response;
+    }
+
+    private static CloseableHttpResponse notifyNoProxy(String url, String authToken, String message) throws IOException {
+        CloseableHttpResponse response = doPost(defaultHttpClient, url, authToken, message);
+        return response;
+    }
+
+    private static CloseableHttpResponse doPost(CloseableHttpClient httpClient, String url, String authToken, String message) throws IOException {
+        CloseableHttpResponse response = null;
+        HttpPost httpPost = null;
+        try {
+            httpPost = decoratePost(new HttpPost(url), authToken, message);
+            response = httpClient.execute(httpPost);
         } finally {
             if(httpPost != null){
                 httpPost.releaseConnection();
             }
         }
-        log.info("Notify success? {}", success);
-        return success;
+        return response;
     }
+
+    private static HttpPost decoratePost(HttpPost httpPost, String authToken, String message) {
+        httpPost.setHeader("content-type", "application/json;charset=UTF-8");
+        if(authToken != null && !authToken.isEmpty()){
+            httpPost.setHeader("Authorization", authToken);
+        }
+        if(message != null && !message.isEmpty()){
+            StringEntity stringEntity = new StringEntity(message, "UTF-8");
+            stringEntity.setContentEncoding("UTF-8");
+            httpPost.setEntity(stringEntity);
+        }
+        return httpPost;
+    }
+
+    private static boolean isNoProxyHost(String url, List<Pattern> noProxyHostPatterns) {
+        boolean result = false;
+        try {
+            String host = new URL(url).getHost();
+            for(Pattern pattern : noProxyHostPatterns) {
+                if(pattern.matcher(host).matches()) {
+                    result = true;
+                    break;
+                }
+            }
+        }
+        catch(MalformedURLException e) {
+            log.error("Invalid URL: {}", url);
+        }
+        return result;
+    }
+
 }

--- a/src/main/java/io/jenkins/plugins/zoom/workflow/ZoomSendStep.java
+++ b/src/main/java/io/jenkins/plugins/zoom/workflow/ZoomSendStep.java
@@ -28,6 +28,8 @@ public class ZoomSendStep extends Step {
     @DataBoundSetter
     private String authToken;
     @DataBoundSetter
+    private boolean jenkinsProxyUsed;
+    @DataBoundSetter
     private String message;
 
     @DataBoundConstructor
@@ -58,7 +60,7 @@ public class ZoomSendStep extends Step {
             TaskListener listener = getContext().get(TaskListener.class);
             MessageBuilder messageBuilder = new MessageBuilder(null, run, listener);
             String msg = messageBuilder.buildPipeMsg(this.step.getMessage());
-            ZoomNotifyClient.notify(this.step.getWebhookUrl(), this.step.getAuthToken(), msg);
+            ZoomNotifyClient.notify(this.step.getWebhookUrl(), this.step.getAuthToken(), this.step.isJenkinsProxyUsed(), msg);
             return null;
         }
     }
@@ -83,9 +85,10 @@ public class ZoomSendStep extends Step {
 
         @POST
         public FormValidation doTestConnection(@QueryParameter("webhookUrl") final String webhookUrl,
-                                               @QueryParameter("authToken") final String authToken){
+                                               @QueryParameter("authToken") final String authToken,
+                                               @QueryParameter("jenkinsProxyUsed") final boolean jenkinsProxyUsed){
             Jenkins.get().checkPermission(Permission.CONFIGURE);
-            if(ZoomNotifyClient.notify(webhookUrl, authToken, null)){
+            if(ZoomNotifyClient.notify(webhookUrl, authToken, jenkinsProxyUsed, null)){
                 return FormValidation.ok("Connection is ok");
             }
             return FormValidation.error("Connect failed");

--- a/src/main/resources/io/jenkins/plugins/zoom/ZoomNotifier/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/zoom/ZoomNotifier/config.jelly
@@ -6,10 +6,13 @@
     <f:entry title="Token" help="/plugin/zoom/token.html">
         <f:textbox field="authToken" />
     </f:entry>
+    <f:entry field="jenkinsProxyUsed" title="Use Jenkins proxy settings" help="/plugin/zoom/jenkinsProxy.html">
+        <f:checkbox default="true" />
+    </f:entry>
 
     <f:validateButton
         title="${%Test Connection}" progress="${%Testing...}"
-        method="testConnection" with="webhookUrl,authToken"/>
+        method="testConnection" with="webhookUrl,authToken,jenkinsProxyUsed"/>
 
     <f:advanced>
         <f:entry field="notifyStart" title="Notify Build Start" help="/plugin/zoom/notify-start.html">

--- a/src/main/resources/io/jenkins/plugins/zoom/workflow/ZoomSendStep/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/zoom/workflow/ZoomSendStep/config.jelly
@@ -7,13 +7,16 @@
     <f:entry title="Token" help="/plugin/zoom/token.html">
         <f:textbox field="authToken" />
     </f:entry>
+    <f:entry field="jenkinsProxyUsed" title="Use Jenkins proxy settings" help="/plugin/zoom/jenkinsProxy.html">
+        <f:checkbox default="true" />
+    </f:entry>
     <f:entry title="Message">
         <f:textbox field="message" />
     </f:entry>
 
     <f:validateButton
         title="${%Test Connection}" progress="${%Testing...}"
-        method="testConnection" with="webhookUrl,authToken"/>
+        method="testConnection" with="webhookUrl,authToken,jenkinsProxyUsed"/>
 
 
 </j:jelly>

--- a/src/main/webapp/jenkinsProxy.html
+++ b/src/main/webapp/jenkinsProxy.html
@@ -1,0 +1,3 @@
+<div>
+    <p>Whether to use Jenkins proxy settings.</p>
+</div>


### PR DESCRIPTION
These changes should fix the issue found [here](https://issues.jenkins-ci.org/browse/JENKINS-58753)

I have added a new setting to afford the use of the proxy configuration in Jenkins (advanced tab of the plugins manager page, programmatically via `hudson.ProxyConfiguration`).

I refactored the existing `io.jenkins.plugins.zoom.ZoomNotifyClient` class to be able to reuse most of the code without any functional changes. In other words, if the Jenkins proxy is not configured at all, not configured correctly, or the new setting prevents the configuration from being used, the plugin behaves exactly as it did before.

Since proxy settings may be set at both via JVM args and via the Jenkins configuration, the new setting is useful to force the new behavior off.

The new proxy behaviour is also slightly less performant than the existing behavior because
(a) proxy settings are checked on every invocation
(b) a new httpClient is created for every proxied request.
Both are by design. This is so that a restart is not needed when proxy settings are modified, and also because the proxy configuration must be set via the httpclient builder.

If you feel this code is ok, please merge it for the next version. I have tested it internally and it is working great for me.
