### PR TITLE
Fix: Secure storage of Zoom integrity token

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     </parent>
     <groupId>io.jenkins.plugins</groupId>
     <artifactId>zoom</artifactId>
-    <version>1.4-SNAPSHOT</version>
+    <version>1.4</version>
     <packaging>hpi</packaging>
     <name>Zoom Plugin</name>
     <description>Send build notification to Zoom channel</description>
@@ -56,6 +56,12 @@
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-step-api</artifactId>
             <version>2.13</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>structs</artifactId>
+                    <groupId>org.jenkins-ci.plugins</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>
@@ -72,6 +78,11 @@
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
             <version>4.5.6</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>credentials</artifactId>
+            <version>2.2.1</version>
         </dependency>
     </dependencies>
     <pluginRepositories>

--- a/src/main/java/io/jenkins/plugins/zoom/ZoomNotifier.java
+++ b/src/main/java/io/jenkins/plugins/zoom/ZoomNotifier.java
@@ -9,6 +9,7 @@ import hudson.tasks.BuildStepMonitor;
 import hudson.tasks.Notifier;
 import hudson.tasks.Publisher;
 import hudson.util.FormValidation;
+import hudson.util.Secret;
 import jenkins.model.Jenkins;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
@@ -25,7 +26,7 @@ public class ZoomNotifier extends Notifier {
     @DataBoundSetter
     private String webhookUrl;
     @DataBoundSetter
-    private String authToken;
+    private Secret authToken;
     @DataBoundSetter
     private boolean jenkinsProxyUsed;
     @DataBoundSetter

--- a/src/main/java/io/jenkins/plugins/zoom/ZoomNotifyClient.java
+++ b/src/main/java/io/jenkins/plugins/zoom/ZoomNotifyClient.java
@@ -1,6 +1,7 @@
 package io.jenkins.plugins.zoom;
 
 import hudson.ProxyConfiguration;
+import hudson.util.Secret;
 import lombok.extern.slf4j.Slf4j;
 
 import org.apache.http.HttpEntity;
@@ -30,6 +31,10 @@ public class ZoomNotifyClient{
 
     private static CloseableHttpClient defaultHttpClient = HttpClients.createDefault();
 
+    public static boolean notify(String url, Secret authToken, boolean jenkinsProxyUsed, String message) {
+        return notify(url, authToken == null ? null : authToken.getPlainText(), jenkinsProxyUsed, message);
+    }
+
     public static boolean notify(String url, String authToken, boolean jenkinsProxyUsed, String message) {
         boolean success = false;
         log.info("Send notification to {}, message: {}", url, message);
@@ -54,7 +59,7 @@ public class ZoomNotifyClient{
             log.error("Invalid URL: {}", url);
         } catch (IOException e2) {
             log.error("Error posting to Zoom, url: {}, message: {}", url, message);
-        } 
+        }
         log.info("Notify success? {}", success);
         return success;
     }

--- a/src/main/java/io/jenkins/plugins/zoom/workflow/ZoomSendStep.java
+++ b/src/main/java/io/jenkins/plugins/zoom/workflow/ZoomSendStep.java
@@ -6,6 +6,7 @@ import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.security.Permission;
 import hudson.util.FormValidation;
+import hudson.util.Secret;
 import io.jenkins.plugins.zoom.MessageBuilder;
 import io.jenkins.plugins.zoom.ZoomNotifyClient;
 import jenkins.model.Jenkins;
@@ -26,7 +27,7 @@ public class ZoomSendStep extends Step {
     @DataBoundSetter
     private String webhookUrl;
     @DataBoundSetter
-    private String authToken;
+    private Secret authToken;
     @DataBoundSetter
     private boolean jenkinsProxyUsed;
     @DataBoundSetter


### PR DESCRIPTION
Replace plain text token storage with Jenkins Secret

This pull request addresses a critical security vulnerability in the Zoom plugin where the integrity token of Zoom accounts was stored in plain text, compromising the CIA triad. The fix involves:

- Replacing plain text storage of Zoom integrity tokens with Jenkins Secret encryption
- Enhancing overall plugin security to prevent potential Zoom account takeovers

This change significantly improves data security by encrypting sensitive information and protecting users from unauthorized access to their Zoom accounts.

Important: Old plain text configurations will be overwritten with the new secure storage method when users resave their jobs.

Testing done:
- Verified the new Secret storage mechanism correctly encrypts and decrypts Zoom tokens
- Tested plugin functionality integrity after implementing the new storage method
- Conducted manual tests to ensure smooth migration from old configurations to the new secure storage
- Verified that old plain text configurations are successfully overwritten when jobs are resaved

Related issues:
https://issues.jenkins.io/browse/SECURITY-3292