### PR TITLE
Add .gitignore for automated release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,23 @@
+target/
+work/
+.vs/
+.vscode/
+
+.project
+.classpath
+.settings/
+
+# Vim
+*.swp
+Session.vim
+
+# Exhuberant ctags
+tags
+
+# emacs files
+*~
+/nbproject/
+/TAGS
+
+# Mac OSX
+.DS_Store


### PR DESCRIPTION
## Add .gitignore for automated release

The automated release process expects `git status -s` to be empty.

Without the .gitignore file, it reports the contents of the target directory.

### Testing done

Confirmed that the `-Dset.changelist` argument to Maven no longer reports the contents of the target directory.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
